### PR TITLE
use traits identifier to show the type name

### DIFF
--- a/util/graphtest/source/graphtest.d
+++ b/util/graphtest/source/graphtest.d
@@ -36,7 +36,7 @@ void main()
             StopWatch watch;
 
             writeln;
-            writeln("Graph type: ", (Graph.directed) ? "directed " : "undirected ", Graph.stringof);
+            writeln("Graph type: ", (Graph.directed) ? "directed " : "undirected ", __traits(identifier, Graph));
             writeln;
 
             writeln("First, a graph of 50 vertices, with edges added one at a time.");


### PR DESCRIPTION
using stringof will not show the typename but only the name of the foreach varaible.